### PR TITLE
5-config-methods.md: set_min: add note about required fields

### DIFF
--- a/documentation/30-complex-field/5-config-methods.md
+++ b/documentation/30-complex-field/5-config-methods.md
@@ -24,7 +24,7 @@ Change the groups' initial visual collapse state. Must be `boolean`. Defaults to
 
 `set_min( $min )`
 
-Minimum number of rows. Must be greater than `0`. Defaults to `-1` (no limit).
+Minimum number of rows. Must be greater than `0`. Defaults to `-1` (no limit). Fields must be required, otherwise set_min will be ignored.
 
 `set_max( $max )`
 


### PR DESCRIPTION
If a complex field is not a required field, set_min will be ignored. This should be mentioned in the docs.