### PR TITLE
Add optional container id

### DIFF
--- a/documentation/10-quickstart.md
+++ b/documentation/10-quickstart.md
@@ -14,7 +14,7 @@ This guide will show you how to install the Carbon Fields library using composer
 
     add_action( 'carbon_fields_register_fields', 'crb_attach_theme_options' );
     function crb_attach_theme_options() {
-        Container::make( 'theme_options', __( 'Theme Options', 'crb' ) )
+        Container::make( 'theme_options', 'sample_theme_options',  __( 'Theme Options', 'crb' ) )
             ->add_fields( array(
                 Field::make( 'text', 'crb_text', 'Text Field' ),
             ) );


### PR DESCRIPTION
Use container name as container id may couse fatal error in some environment when if the container name is non-ascii characters. add an explicit container id can avoid the error.