### PR TITLE
Remove extra symbol on association.md

### DIFF
--- a/src/learn/fields/association.md
+++ b/src/learn/fields/association.md
@@ -78,7 +78,7 @@ array(
         'id' => 16,
         'type' => 'term',
         'subtype' => 'category',
-        'value' => 'term:category:16',a
+        'value' => 'term:category:16',
     )
 )
 */


### PR DESCRIPTION
Removed extra symbol 'a' on the example result.